### PR TITLE
feat: 음식 이미지 분석 잔여 횟수 API 구성

### DIFF
--- a/server/apis/food_image.py
+++ b/server/apis/food_image.py
@@ -201,3 +201,26 @@ def search_similar_food(query_name):
     
     # 최대 3개의 결과 반환 또는 null
     return result  
+
+
+# Redis의 정의된 잔여 기능 횟수 확인
+def get_remaining_requests(member_id: int):
+
+    try:
+        # Redis 키 생성
+        redis_key = f"rate_limit:{member_id}"
+
+        # Redis에서 사용자의 요청 횟수 조회
+        current_count = redis_client.get(redis_key)
+
+        # 요청 횟수가 없다면 기본값 반환(RATE_LIMIT)
+        if current_count is None:
+            return RATE_LIMIT
+
+        # 남은 요청 횟수
+        remaining_requests = max(RATE_LIMIT - int(current_count), 0)
+        return remaining_requests
+
+    except Exception as e:
+        logger.error(f"잔여 기능 횟수 확인 중 에러가 발생했습니다: {e}")
+        raise ServiceConnectionError()

--- a/server/routers/diet_analysis.py
+++ b/server/routers/diet_analysis.py
@@ -12,7 +12,7 @@ router = APIRouter(
 )
 
 # 전체 식습관 분석 라우터
-@router.get("/", responses=get_user_analysis_responses)
+@router.get("/diet", responses=get_user_analysis_responses)
 def get_user_analysis(db: Session = Depends(get_db), member_id: int = Depends(get_current_member)):
     
     # 최신 분석 상태 확인

--- a/server/routers/food_image_analysis.py
+++ b/server/routers/food_image_analysis.py
@@ -1,7 +1,7 @@
 import logging
 import json
 from fastapi import APIRouter, Depends, File, UploadFile
-from apis.food_image import food_image_analyze, search_similar_food, rate_limit_user, process_image_to_base64
+from apis.food_image import food_image_analyze, search_similar_food, rate_limit_user, process_image_to_base64, get_remaining_requests
 from auth.decoded_token import get_current_member
 from errors.business_exception import InvalidFoodImageError
 from swagger.response_config import analyze_food_image_responses
@@ -24,7 +24,7 @@ router = APIRouter(
 
 
 # 음식 이미지 분석 API
-@router.post("/", responses=analyze_food_image_responses)
+@router.post("/image", responses=analyze_food_image_responses)
 async def analyze_food_image(file: UploadFile = File(...), member_id: int = Depends(get_current_member)):
     
     """
@@ -88,6 +88,24 @@ async def analyze_food_image(file: UploadFile = File(...), member_id: int = Depe
             "remaining_requests": remaining_requests,
             "food_info": similar_food_results
         },
+        "error": None
+    }
+
+    return response
+
+
+# 기능 잔여 횟수 확인 API
+@router.get("/count", responses=analyze_food_image_responses)
+def remaning_requests_check(member_id: int = Depends(get_current_member)):
+
+    """
+    사용자의 남은 요청 횟수 반환
+    """
+    remaining_requests = get_remaining_requests(member_id)
+
+    response = {
+        "success": True,
+        "response": remaining_requests,
         "error": None
     }
 


### PR DESCRIPTION
## 📌 관련 이슈

close #40 

- 기능 잔여 횟수 조회 API 구현: /v1/ai/food_image_analysis/count

## 🔑 주요 변경사항

- 기존 uri 변경
    - 음식 이미지 분석: /v1/ai/food_image_analysis/image
    - 식습관 분석:  /v1/ai/diet_analysis/diet
